### PR TITLE
fix: update working userinfo url

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -109,7 +109,7 @@ app.get(`/${redirectURI}`, async (req, res) => {
   // Fetch the user's profile with the access token and bearer
   const googleUser = await axios
     .get(
-      `https://www.googleapis.com/oauth2/v1/userinfo?alt=json&access_token=${access_token}`,
+      `https://openidconnect.googleapis.com/v1/userinfo?alt=json&access_token=${access_token}`,
       {
         headers: {
           Authorization: `Bearer ${id_token}`,


### PR DESCRIPTION
problem: old url deprecated and not working.
see: https://stackoverflow.com/questions/24442668/google-oauth-api-to-get-users-email-address/24510214#24510214

solution: use updated url